### PR TITLE
feat: show state which key is a symbol type

### DIFF
--- a/packages/app-frontend/src/features/inspector/StateInspector.vue
+++ b/packages/app-frontend/src/features/inspector/StateInspector.vue
@@ -60,7 +60,7 @@ export default {
           (keyOrder[a] || (a.toLowerCase().charCodeAt(0) + 999)) -
           (keyOrder[b] || (b.toLowerCase().charCodeAt(0) + 999))
         )
-      })
+      }).concat(Object.getOwnPropertySymbols(this.state).map(name => name.description ?? 'Anonymous Symbol'))
     },
 
     totalCount () {


### PR DESCRIPTION
when i use 
`provide(Symbol, myValue)`
i can not inspect in devtools,
because Symbol key can't get by Object.keys(),
