### PR TITLE
fix: broken URL to open-in-editor docs

### DIFF
--- a/packages/shared-utils/src/util.ts
+++ b/packages/shared-utils/src/util.ts
@@ -699,7 +699,7 @@ export function openInEditor (file) {
       } else {
         console.log('%c' + msg, 'color:red')
       }
-      console.log('Check the setup of your project, see https://github.com/vuejs/devtools/blob/main/docs/guide/open-in-editor.md')
+      console.log('Check the setup of your project, see https://devtools.vuejs.org/guide/open-in-editor.html')
     }
   })`
   if (isChrome) {


### PR DESCRIPTION
Currently when trying to "Open in editor" when it's not configured, a console message is printed with a URL to the configuration guide.
The URL is broken and doesn't work, this PR fixes the URL.