### PR TITLE
fix: handle missing raw setup state (fix #2123)

### DIFF
--- a/packages/app-backend-vue3/src/components/data.ts
+++ b/packages/app-backend-vue3/src/components/data.ts
@@ -177,7 +177,7 @@ function processState(instance) {
 }
 
 function processSetupState(instance) {
-  const raw = instance.devtoolsRawSetupState
+  const raw = instance.devtoolsRawSetupState || {}
   const combinedSetupState = (Object.keys(instance.setupState).length
     ? instance.setupState
     : instance.exposed


### PR DESCRIPTION
### Description

When setup function returns render function there's no devtoolsRawSetupState and setupState is empty. When the same component exposes some data the loop will try to access it from the `raw` const. To prevent accessing property of undefined we'll default `raw` to an empty object.

I reproduced this here: https://stackblitz.com/edit/vitejs-vite-zhshuz?file=src%2Fmain.js

fixes #2123

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [x] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
